### PR TITLE
Updated 100-network-reverse-proxy.yaml

### DIFF
--- a/obsidian/100-network-reverse-proxy.yaml
+++ b/obsidian/100-network-reverse-proxy.yaml
@@ -16,6 +16,10 @@ services:
         source: /zfs_master/docker/data/haproxy/haproxy.cfg
         target: /usr/local/etc/haproxy/haproxy.cfg
         read_only: true
+      - type: bind
+        source: /zfs_master/docker/data/haproxy/certs
+        target: /usr/local/etc/haproxy/certs
+        read_only: true
     networks:
       vlan10:
         ipv4_address: 192.168.10.40


### PR DESCRIPTION
The above changeset is for mapping the certs folder with the Docker container. Need to secure the OCP VIRT URL.